### PR TITLE
Automatic download of latest EVDI driver RPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Automatically find the EVDI driver's URL download link, which installs the latest RPM version.
+- Added confirm prompt after finding the EVDI download URL.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fixed user selecting "No" when installing the EVDI driver bug on dnf prompt.
+
+### Security

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ git clone https://github.com/thehaniak/wavlink-fedora.git
 cd wavlink-fedora
 ```
 
-
 Add run permissions and run the install.sh script as root:
 
 ```bash
@@ -54,8 +53,7 @@ If you're too lazy to check the code 😜 ...
 
 - Cleanup the install script.
 - Make it possible to uninstall the SMI and EVDI drivers.
-- Remove upstart script support, as it's no longer necessary from Fedora 41.
-
+- Remove upstart script support, as it's no longer necessary on Fedora>=41.
 
 # Wavlink Original License
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Run the steps below at your own risk.**
 
 I have throughly tested this with the aforementioned device and distro and it worked, but I do not guarantee it will work on your settup.
 
-## How to install 
+## How to install
 
 Clone this repo:
 
-```
+```bash
 git clone https://github.com/thehaniak/wavlink-fedora.git
 cd wavlink-fedora
 ```
@@ -26,7 +26,7 @@ cd wavlink-fedora
 
 Add run permissions and run the install.sh script as root:
 
-```
+```bash
 chmod +x install.sh
 sudo ./install.sh
 ```
@@ -35,7 +35,7 @@ The install script will prompt you to install the EVDI driver. If you approve, i
 
 If the device is not working straight away, just start the **smiusbdisplay.service**.
 
-```
+```bash
 systemctl start smiusbdisplay.service
 ```
 
@@ -45,15 +45,16 @@ After installation, you _**shoud**_ reboot to make sure everything is working pr
 
 If you're too lazy to check the code 😜 ...
 
-1) Downloads and installs the _latest_ EVDI driver RPM from [displaylink-rpm](https://github.com/displaylink-rpm/displaylink-rpm/releases) (the version/link is actually hardcoded, but can be changed easily)
+1) Downloads and installs the _latest_ EVDI driver RPM from [displaylink-rpm](https://github.com/displaylink-rpm/displaylink-rpm/releases)
 2) Copies the binaries (firmware and driver) to _/opt/siliconmotion_.
-3) Installs _smiusbdisplay.service_.
+3) Installs systemd _smiusbdisplay.service_.
 
 # Next steps
 
 - Cleanup the install script.
-- Make the EVDI version installation dynamic.
 - Make it possible to uninstall the SMI and EVDI drivers.
+- Remove upstart script support, as it's no longer necessary from Fedora 41.
+
 
 # Wavlink Original License
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ chmod +x install.sh
 sudo ./install.sh
 ```
 
-The install script will prompt you to install the EVDI driver. If you approve, it will also install the SMI USB driver and service.
+The install script will prompt you to install the EVDI driver.
+If you select Yes, it will also install the SMI USB driver and service.
 
-If the device is not working straight away, just start the **smiusbdisplay.service**.
+If the device is not working straight away, try starting **smiusbdisplay.service**.
 
 ```bash
 systemctl start smiusbdisplay.service

--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,12 @@ readonly COREDIR=/opt/siliconmotion
 readonly OTHERPDDIR=/opt/displaylink
 readonly LOGPATH=/var/log/SMIUSBDisplay
 readonly PRODUCT="Silicon Motion Linux USB Display Software"
-VERSION=2.22.1.0
+readonly FEDORA_VERSION=$(cat /etc/fedora-release | cut -d' ' -f3)
+readonly ARCHITECTURE=$(arch)
+readonly FEDORA_SUPPORTED_VERSIONS="41 42"
+readonly VERSION=1.0.1
 ACTION=install
 
-#FEDORA41_DISPLAYLINK_RPM=https://github.com/displaylink-rpm/displaylink-rpm/releases/download/v6.1.0-2/fedora-41-displaylink-1.14.7-4.github_evdi.x86_64.rpm
-FEDORA41_DISPLAYLINK_RPM=https://github.com/displaylink-rpm/displaylink-rpm/releases/download/v6.1.0-3/fedora-40-displaylink-1.14.8-1.github_evdi.x86_64.rpm
 
 add_upstart_script()
 {
@@ -47,7 +48,7 @@ script
 	fi
 	dkms install /opt/siliconmotion/module/
 	if [ $? == 0 ]; then
-		cp /opt/siliconmotion/evdi.conf /etc/modprobe.d 
+		cp /opt/siliconmotion/evdi.conf /etc/modprobe.d
 		modprobe evdi
 	fi
     fi
@@ -135,20 +136,30 @@ cleanup()
 binary_location()
 {
   echo "$(pwd)/binaries"
-  
+
 }
 
 install()
 {
   echo "Installing..."
 
-  echo "Installing EVDI displaylink driver from URL: ${FEDORA41_DISPLAYLINK_RPM}"
-  dnf install ${FEDORA41_DISPLAYLINK_RPM}
+  echo "Finding latest EVDI driver for Fedora ${FEDORA_VERSION} ${ARCHITECTURE}..."
+
+  jq_query=".assets[] | select(.browser_download_url | contains(\"${ARCHITECTURE}\") and contains(\"fedora-${FEDORA_VERSION}\")) | .browser_download_url"
+
+  DISPLAYLINK_RPM=$(curl -sL https://api.github.com/repos/displaylink-rpm/displaylink-rpm/releases/latest | jq -r "${jq_query}")
+
+  echo "Found EVDI displaylink driver URL: ${DISPLAYLINK_RPM}"
+
+  read -rp 'Do you want to continue with EVDI installation? [y/N] ' CHOICE
+
+  [[ "${CHOICE:-N}" == "${CHOICE#[nN]}" ]] || exit 1
+
+  dnf install ${DISPLAYLINK_RPM}
 
   mkdir -p $COREDIR
   chmod 0755 $COREDIR
-  
-  # cp -f "$SELF" "$COREDIR"
+
   echo "Copying binaries..."
   cp -f $(pwd)/binaries/* $COREDIR
 
@@ -160,14 +171,14 @@ install()
   chmod 0755 $COREDIR/SMIUSBDisplayManager
   chmod 0755 $COREDIR/libusb*.so*
   chmod 0755 $COREDIR/SMIFWLogCapture
-  
+
   ln -sf $COREDIR/SMIFWLogCapture /usr/bin/SMIFWLogCapture
   chmod 0755 /usr/bin/SMIFWLogCapture
 
   source smi-udev-installer.sh
   siliconmotion_bootstrap_script="$COREDIR/smi-udev.sh"
   create_bootstrap_file "$SYSTEMINITDAEMON" "$siliconmotion_bootstrap_script"
-  
+
   add_wayland_script
 
   echo "Adding udev rule for SiliconMotion devices"
@@ -211,7 +222,7 @@ uninstall()
   rm -f /etc/udev/rules.d/99-smiusbdisplay.rules
   udevadm control -R
   udevadm trigger
-  
+
   remove_wayland_script
 
   echo "[ Removing Core folder ]"
@@ -221,7 +232,7 @@ uninstall()
 
   if [ -d $OTHERPDDIR ]; then
 	  echo "WARNING: There are other products in the system using EVDI."
-  else 
+  else
 	  echo "Removing EVDI from kernel tree, DKMS, and removing sources."
     	  (
     	  cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && \
@@ -267,15 +278,19 @@ detect_init_daemon()
 
 distro_check()
 {
-  if [ -f /etc/fedora-release ] && grep -q "Fedora release 41" /etc/fedora-release
+  if [ -f /etc/fedora-release ] && grep -q ${FEDORA_VERSION} /etc/fedora-release \\
   then
-    echo -n "Fedora 41 recognized. "
-  else
-    echo -n "This script has not been tested on your distro/release. "
-    
-    read -rp 'Do you want to continue? [y/N] ' CHOICE
+    echo "Found ${FEDORA_VERSION} on arch ${ARCHITECTURE}"
+    if [[ "${FEDORA_SUPPORTED_VERSIONS}" =~ (" "|^)${FEDORA_VERSION}(" "|$) ]]
+    then
+      echo -n "Fedora ${FEDORA_VERSION} recognized. "
+    else
+      echo -n "This script has not been tested on your distro/release. "
 
-    [[ "${CHOICE:-N}" == "${CHOICE#[nN]}" ]] || exit 1
+      read -rp 'Do you want to continue? [y/N] ' CHOICE
+
+      [[ "${CHOICE:-N}" == "${CHOICE#[nN]}" ]] || exit 1
+    fi
   fi
 
   echo "Will proceed..."

--- a/install.sh
+++ b/install.sh
@@ -306,7 +306,6 @@ if [[ "$1" == "" || "$1" == "install" ]]
 then
   install
 elif [[ "$1" == "remove" ]]
-  echo "Remove still pending..."
+  echo "Remove not implemented."
 fi
 
-# systemctl start smiusbdisplay.service

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,6 @@ readonly PRODUCT="Silicon Motion Linux USB Display Software"
 readonly FEDORA_VERSION=$(cat /etc/fedora-release | cut -d' ' -f3)
 readonly ARCHITECTURE=$(arch)
 readonly FEDORA_SUPPORTED_VERSIONS="41 42"
-ACTION=install
 
 
 add_upstart_script()
@@ -160,7 +159,7 @@ install()
   chmod 0755 $COREDIR
 
   echo "Copying binaries..."
-  cp -f $(pwd)/binaries/* $COREDIR
+  cp -vf $(pwd)/binaries/* $COREDIR
 
   echo "Creating symlinks and setting permissions..."
   ln -sf $COREDIR/libusb-1.0.so.0.2.0 $COREDIR/libusb-1.0.so.0
@@ -303,6 +302,11 @@ fi
 [ -z "$SYSTEMINITDAEMON" ] && detect_init_daemon || echo "Trying to use the forced init system: $SYSTEMINITDAEMON"
 distro_check
 
-install
+if [[ "$1" == "" || "$1" == "install" ]]
+then
+  install
+elif [[ "$1" == "remove" ]]
+  echo "Remove still pending..."
+fi
 
-systemctl start smiusbdisplay.service
+# systemctl start smiusbdisplay.service

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,6 @@ readonly PRODUCT="Silicon Motion Linux USB Display Software"
 readonly FEDORA_VERSION=$(cat /etc/fedora-release | cut -d' ' -f3)
 readonly ARCHITECTURE=$(arch)
 readonly FEDORA_SUPPORTED_VERSIONS="41 42"
-readonly VERSION=1.0.1
 ACTION=install
 
 
@@ -155,7 +154,7 @@ install()
 
   [[ "${CHOICE:-N}" == "${CHOICE#[nN]}" ]] || exit 1
 
-  dnf install ${DISPLAYLINK_RPM}
+  dnf install ${DISPLAYLINK_RPM} lsb_release || exit 1
 
   mkdir -p $COREDIR
   chmod 0755 $COREDIR


### PR DESCRIPTION
`install.sh` script is now able to fetch the latest RPM of the EVDI displaylink driver from github.